### PR TITLE
Fix FileNotFoundError : if the zip doesn't have a db in it 

### DIFF
--- a/SQLiteWalker.py
+++ b/SQLiteWalker.py
@@ -121,6 +121,7 @@ def main():
                 files = my_zip.namelist()
                 output_ts = time.strftime("%Y%m%d-%H%M%S")
                 out_folder = output_path + base + output_ts
+                os.makedirs(out_folder + splitter + 'db_out')
                 for file in files:
                     file_name = file.rsplit("/",1)
                     if file.endswith(('-shm','-wal')):


### PR DESCRIPTION
Occur when the zip doesn't have a sqlite in it.


```
Traceback (most recent call last):
  File "c:\Users\***\git\SQLiteWalker\SQLiteWalker.py", line 269, in <module>
    main()
  File "c:\Users\***\git\SQLiteWalker\SQLiteWalker.py", line 247, in main
    with open(out_folder + splitter + 'db_list.tsv', 'w', newline='') as f_output:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '\\\\?\\C:\\Users\\***\\git\\SQLiteWalker\\test\\SQLiteWalker_Out_20230504-144101\\db_list.tsv' 
`